### PR TITLE
Supprt chunk prefill

### DIFF
--- a/lmcache_vllm/vllm_adapter.py
+++ b/lmcache_vllm/vllm_adapter.py
@@ -264,7 +264,6 @@ def lmcache_retrieve_kv(
     # enumerate different requests
     # FIXME(Kuntai): This impl assumes that all requests are prefill.
     num_request_not_found = 0
-    num_request_decode = 0
     for idx, slen in enumerate(seq_lens):
 
         start_pos = sum(seq_lens[:idx])
@@ -283,7 +282,7 @@ def lmcache_retrieve_kv(
 
         if num_computed_tokens == 0:
             num_request_not_found += 1
-            #num_computed_tokens_list.append(0)
+            num_computed_tokens_list.append(0)
             continue
 
         num_computed_tokens_list.append(num_computed_tokens)
@@ -313,7 +312,9 @@ def lmcache_retrieve_kv(
             )
     
     # Some of the request can be skipped for a bit
-    if num_request_not_found == 0:#< len(seq_lens): 
+    # TODO(Jiayi): need to test full prefill and partial prefill
+    # in a single batch
+    if num_request_not_found < len(seq_lens): 
         rebuilt_model_input = build_partial_prefill_input(
             model_input,
             input_tokens_list,

--- a/lmcache_vllm/vllm_adapter.py
+++ b/lmcache_vllm/vllm_adapter.py
@@ -127,7 +127,7 @@ def lmcache_should_store(
     if not has_engine or kv_caches is None:
         return False
 
-    attn_meta = model_input.attn_metadata#.prefill_metadata
+    attn_meta = model_input.attn_metadata
     prefill_meta = attn_meta.prefill_metadata
     
     # TODO (yihua): Current implementation is in GPUModelRunner, so we do

--- a/lmcache_vllm/vllm_adapter.py
+++ b/lmcache_vllm/vllm_adapter.py
@@ -139,7 +139,7 @@ def lmcache_should_store(
     # check if the current run is profiling
     is_profile_run = (kv_caches is None) or (kv_caches[0] is None)
     
-    # FIXME(Jiayi): need to support multiple prefills in a single batch
+    # FIXME(Jiayi): need to support chunked prefill (batch prefill and decode)
     # check if the current run is prefill
     is_prefill_run = ((attn_meta.num_prefills == len(model_input.seq_lens))\
         and (prefill_meta is not None))

--- a/lmcache_vllm/vllm_adapter.py
+++ b/lmcache_vllm/vllm_adapter.py
@@ -246,10 +246,6 @@ def lmcache_store_kv(
     engine = LMCacheEngineBuilder.get(ENGINE_NAME)
     assert engine is not None, "LMCache engine is not initialized."
 
-
-    with torch.cuda.stream(LMCACHE_CUDA_STREAM):
-        input_tokens_tensor = model_input.input_tokens.detach().clone().cpu()
-
     seq_lens = model_input.attn_metadata.seq_lens
         
     if hasattr(model_executable.model, "start_layer"):

--- a/lmcache_vllm/vllm_adapter.py
+++ b/lmcache_vllm/vllm_adapter.py
@@ -241,7 +241,6 @@ def lmcache_store_kv(
             current_slot_mapping = current_slot_mapping.flatten()
             current_slot_mapping = current_slot_mapping[:slen]
             current_slot_mapping = current_slot_mapping.to(slot_mapping_dtype)
-            print(f"store: {current_tokens}")
         
         for layer_id in range(start_layer, end_layer):
             kv_cache = kv_caches[layer_id - start_layer]
@@ -313,9 +312,6 @@ def lmcache_retrieve_kv(
         end_pos = start_pos + slen
         current_tokens = input_tokens_tensor[start_pos:end_pos]
         num_tokens = slen
-        
-        if len(current_tokens) >= 1024:
-            print(f"retrieve: {current_tokens[:768]}")
 
         input_tokens_list.append(current_tokens)
         start_pos_list.append(start_pos)

--- a/lmcache_vllm/vllm_adapter.py
+++ b/lmcache_vllm/vllm_adapter.py
@@ -150,7 +150,6 @@ def lmcache_should_store(
         and (prefill_meta is not None))
     if prefill_run:
         return "prefill"
-    return None
 
     
     # Determine whether to save decoded KV cache

--- a/lmcache_vllm/vllm_adapter.py
+++ b/lmcache_vllm/vllm_adapter.py
@@ -93,7 +93,7 @@ def lmcache_should_retrieve(
     if not has_engine or kv_caches is None:
         return False
 
-    attn_meta = model_input.attn_metadata#.prefill_metadata
+    attn_meta = model_input.attn_metadata
     prefill_meta = attn_meta.prefill_metadata
     
     # check if the current run is profiling
@@ -101,7 +101,7 @@ def lmcache_should_retrieve(
     # check if the current run is prefill
     is_prefill_run = ((attn_meta.num_prefills == len(model_input.seq_lens))\
         and prefill_meta is not None)
-    #prefill_meta is not None
+
     # for disaggregated prefilling: allow bypassing model execution
 
     return all([
@@ -141,7 +141,7 @@ def lmcache_should_store(
     # FIXME(Jiayi): need to support multiple prefills in a single batch
     # check if the current run is prefill
     is_prefill_run = ((attn_meta.num_prefills == len(model_input.seq_lens))\
-        and (prefill_meta is not None)) #prefill_meta is not None
+        and (prefill_meta is not None))
 
 
     return all([

--- a/lmcache_vllm/vllm_adapter.py
+++ b/lmcache_vllm/vllm_adapter.py
@@ -128,7 +128,8 @@ def lmcache_should_store(
     :param kv_caches: The paged memory
     :type kv_caches: List[torch.Tensor]
 
-    :return: True if we should store KV into LMCache, False otherwise.
+    :return: StoreStatus.PREFILL/DECODE if we should store KV after PREFILL/DECODE.
+             StoreStatus.NONE if no storing is required.
     """
     engine = LMCacheEngineBuilder.get(ENGINE_NAME)
     has_engine = engine is not None

--- a/lmcache_vllm/vllm_adapter.py
+++ b/lmcache_vllm/vllm_adapter.py
@@ -93,12 +93,15 @@ def lmcache_should_retrieve(
     if not has_engine or kv_caches is None:
         return False
 
-    prefill_meta = model_input.attn_metadata.prefill_metadata
-
+    attn_meta = model_input.attn_metadata#.prefill_metadata
+    prefill_meta = attn_meta.prefill_metadata
+    
     # check if the current run is profiling
     is_profile_run = (kv_caches is None) or (kv_caches[0] is None)
     # check if the current run is prefill
-    is_prefill_run = prefill_meta is not None
+    is_prefill_run = ((attn_meta.num_prefills == len(model_input.seq_lens))\
+        and prefill_meta is not None)
+    #prefill_meta is not None
     # for disaggregated prefilling: allow bypassing model execution
 
     return all([
@@ -123,8 +126,9 @@ def lmcache_should_store(
     if not has_engine or kv_caches is None:
         return False
 
-    prefill_meta = model_input.attn_metadata.prefill_metadata
-
+    attn_meta = model_input.attn_metadata#.prefill_metadata
+    prefill_meta = attn_meta.prefill_metadata
+    
     # TODO (yihua): Current implementation is in GPUModelRunner, so we do
     #               not need to check the type of model_runner
     #from vllm.worker.model_runner import GPUModelRunnerBase
@@ -133,8 +137,11 @@ def lmcache_should_store(
 
     # check if the current run is profiling
     is_profile_run = (kv_caches is None) or (kv_caches[0] is None)
+    
+    # FIXME(Jiayi): need to support multiple prefills in a single batch
     # check if the current run is prefill
-    is_prefill_run = prefill_meta is not None
+    is_prefill_run = ((attn_meta.num_prefills == len(model_input.seq_lens))\
+        and (prefill_meta is not None)) #prefill_meta is not None
 
 
     return all([
@@ -257,6 +264,7 @@ def lmcache_retrieve_kv(
     # enumerate different requests
     # FIXME(Kuntai): This impl assumes that all requests are prefill.
     num_request_not_found = 0
+    num_request_decode = 0
     for idx, slen in enumerate(seq_lens):
 
         start_pos = sum(seq_lens[:idx])
@@ -275,6 +283,7 @@ def lmcache_retrieve_kv(
 
         if num_computed_tokens == 0:
             num_request_not_found += 1
+            #num_computed_tokens_list.append(0)
             continue
 
         num_computed_tokens_list.append(num_computed_tokens)
@@ -302,8 +311,9 @@ def lmcache_retrieve_kv(
                 layer.self_attn.attn._k_scale,
                 layer.self_attn.attn._v_scale,
             )
-
-    if num_request_not_found == 0: # All the request can be skipped for a bit
+    
+    # Some of the request can be skipped for a bit
+    if num_request_not_found == 0:#< len(seq_lens): 
         rebuilt_model_input = build_partial_prefill_input(
             model_input,
             input_tokens_list,
@@ -314,7 +324,7 @@ def lmcache_retrieve_kv(
         )
         logger.debug("Rebuilt the input!")
         return rebuilt_model_input
-
+    
     logger.debug("Returning the original input!")
     return model_input
 
@@ -431,6 +441,7 @@ def build_partial_prefill_input(
         virtual_engine=model_input.virtual_engine,
         sampling_metadata=rebuilt_sampling_metadata,
         is_prompt=model_input.is_prompt,
+        async_callback=model_input.async_callback
     )
 
     return rebuilt_model_input

--- a/lmcache_vllm/vllm_adapter.py
+++ b/lmcache_vllm/vllm_adapter.py
@@ -144,22 +144,22 @@ def lmcache_should_store(
     if is_profile_run:
         return None
 
-    if not engine.save_decode_cache:
-        # FIXME(Jiayi): need to support chunked prefill (batch prefill and decode)
-        # check if the current run is prefill
-        is_prefill_run = ((attn_meta.num_prefills == len(model_input.seq_lens))\
-            and (prefill_meta is not None))
-        if prefill_run:
-            return "prefill"
-        return None
+    # FIXME(Jiayi): need to support chunked prefill (batch prefill and decode)
+    # check if the current run is prefill
+    is_prefill_run = ((attn_meta.num_prefills == len(model_input.seq_lens))\
+        and (prefill_meta is not None))
+    if prefill_run:
+        return "prefill"
+    return None
 
     
     # Determine whether to save decoded KV cache
     #seq_groups = model_input.sampling_metadata.seq_groups
-    seq_lens = model_input.attn_metadata.seq_lens
-    for seq_len in seq_lens:
-        if seq_len % 256 == 0:
-            return "decode"
+    if engine.save_decode_cache:
+        seq_lens = model_input.attn_metadata.seq_lens
+        for seq_len in seq_lens:
+            if seq_len % 256 == 0:
+                return "decode"
     return None
 
 

--- a/lmcache_vllm/vllm_adapter.py
+++ b/lmcache_vllm/vllm_adapter.py
@@ -157,7 +157,7 @@ def lmcache_should_store(
     if engine.save_decode_cache:
         seq_lens = model_input.attn_metadata.seq_lens
         for seq_len in seq_lens:
-            if seq_len % 256 == 0:
+            if seq_len % engine.chunk_size == 0:
                 return "decode"
     return None
 

--- a/lmcache_vllm/vllm_injection.py
+++ b/lmcache_vllm/vllm_injection.py
@@ -13,7 +13,8 @@ from vllm.distributed import get_pp_group
 
 from lmcache_vllm.vllm_adapter import (
         init_lmcache_engine, lmcache_should_store, lmcache_should_retrieve,
-        lmcache_store_kv, lmcache_retrieve_kv, close_lmcache_engine)
+        lmcache_store_kv, lmcache_retrieve_kv, close_lmcache_engine,
+        StoreStatus)
 
 from lmcache.logging import init_logger
 logger = init_logger(__name__)
@@ -94,10 +95,10 @@ def new_execute_model(
 
     # LMCache storing
     should_store = lmcache_should_store(model_input, kv_caches)
-    if should_store is not None:
-        assert should_store in ["prefill", "decode"]
+    if should_store != StoreStatus.NONE:
+        assert should_store in [StoreStatus.PREFILL, StoreStatus.DECODE]
         logger.info(f"KV cache saving mode: {should_store}")
-        is_prefill = (should_store == "prefill")
+        is_prefill = (should_store == StoreStatus.PREFILL)
         lmcache_store_kv(model_executable, model_input, kv_caches,
                          is_prefill)
 

--- a/lmcache_vllm/vllm_injection.py
+++ b/lmcache_vllm/vllm_injection.py
@@ -118,8 +118,11 @@ def new_execute_model(
  
     if not self.is_driver_worker:
         return []
- 
+
+    # Jiayi: this call back calls `_process_model_outputs`
+    # in vllm/engine/llm_engine.py
     if model_input.async_callback is not None:
+        #logger.debug(f"Model input after running: {model_input}")
         model_input.async_callback()
  
     # Sample the next token.

--- a/lmcache_vllm/vllm_injection.py
+++ b/lmcache_vllm/vllm_injection.py
@@ -122,7 +122,6 @@ def new_execute_model(
     # Jiayi: this call back calls `_process_model_outputs`
     # in vllm/engine/llm_engine.py
     if model_input.async_callback is not None:
-        #logger.debug(f"Model input after running: {model_input}")
         model_input.async_callback()
  
     # Sample the next token.

--- a/lmcache_vllm/vllm_injection.py
+++ b/lmcache_vllm/vllm_injection.py
@@ -35,17 +35,18 @@ def new_execute_model(
     is_skip = False
     if retrieve_status != RetrieveStatus.NONE:
         logger.info(f"KV cache retrieving mode: {retrieve_status}")
-        logger.debug(f"{model_input.seq_lens}")
         model_input, is_skip = lmcache_retrieve_kv(
             self.model, model_input, kv_caches, retrieve_status)
-        
+
         if is_skip: # create a hiddens_states
+            logger.debug("Prefill is entirely skipped")
             num_tok = len(model_input.input_tokens)
             num_dim = self.model.model.embed_tokens.embedding_dim
-            self.hidden_or_intermediate_states_fake = \
-                torch.ones(num_tok, num_dim, 
-                           device=model_input.input_tokens.device,
-                           dtype=self.model.model.embed_tokens.weight.dtype)
+            if not hasattr(self, 'hidden_or_intermediate_states_fake'):
+                self.hidden_or_intermediate_states_fake = \
+                    torch.ones(num_tok, num_dim, 
+                            device=model_input.input_tokens.device,
+                            dtype=self.model.model.embed_tokens.weight.dtype)
             
     
     # TODO(Jiayi): Currently, we do not handle the last chunk in chunk prefill


### PR DESCRIPTION
This PR resolves https://github.com/LMCache/LMCache/issues/144

In store, we store the KV cache after each chunk prefill.

In load, we load before each prefill and skip the entire computation if all KV cache of that chunk is hit.
We do not handle batched chunk prefill + decode for now as the expected performance gain is marginal. We need to put our injection point to somewhere in the scheduler in order to spped up this case.

Performance improvement: 7.3s (naive chunked prefill) -> 3.2s (local cpu cache).
Potential room for performance optimization: having a buffer somewhere in vllm or lmcache, and only load (concat and inject the cache into vllm) or store once (created a draft issue).