### PR TITLE
Optimize chunk prefill performance

### DIFF
--- a/lmcache_vllm/vllm_adapter.py
+++ b/lmcache_vllm/vllm_adapter.py
@@ -351,6 +351,7 @@ def lmcache_should_store(
                 store_status[seq_data_idx] = StoreStatus.CHUNK_PREFILL
                 seq_data_idx += 1 
                 continue
+            
             for seqid, seq_data in seq_group_metadata.seq_data.items():
                 if seq_data.get_len()-1 != selected_token_indices[selected_token_indices_idx]:
                     # last chunk in chunk prefill

--- a/lmcache_vllm/vllm_adapter.py
+++ b/lmcache_vllm/vllm_adapter.py
@@ -351,7 +351,10 @@ def lmcache_should_store(
                 store_status[seq_data_idx] = StoreStatus.CHUNK_PREFILL
                 seq_data_idx += 1 
                 continue
+<<<<<<< HEAD
             
+=======
+>>>>>>> bugfix 22
             for seqid, seq_data in seq_group_metadata.seq_data.items():
                 if seq_data.get_len()-1 != selected_token_indices[selected_token_indices_idx]:
                     # last chunk in chunk prefill

--- a/lmcache_vllm/vllm_adapter.py
+++ b/lmcache_vllm/vllm_adapter.py
@@ -421,9 +421,9 @@ def lmcache_store_kv(
         for seqid, seq_data in seq_group_metadata.seq_data.items():
             status = store_status[seq_data_idx]
             # TODO (Jiayi): can chunk prefill and vllm prefix caching use the same logic?
-            if status in [StoreStatus.NONE, StoreStatus.CHUNK_PREFILL]:
+            if status in [StoreStatus.NONE]:
                 continue
-            elif status in [StoreStatus.SUFFIX_PREFILL]:
+            elif status in [StoreStatus.SUFFIX_PREFILL, StoreStatus.CHUNK_PREFILL]:
                 seq_len = seq_lens[seq_data_idx]
             else:
                 seq_len = seq_data.get_len()

--- a/lmcache_vllm/vllm_adapter.py
+++ b/lmcache_vllm/vllm_adapter.py
@@ -421,15 +421,15 @@ def lmcache_store_kv(
         for seqid, seq_data in seq_group_metadata.seq_data.items():
             status = store_status[seq_data_idx]
             # TODO (Jiayi): can chunk prefill and vllm prefix caching use the same logic?
-            if status in [StoreStatus.CHUNK_PREFILL, StoreStatus.SUFFIX_PREFILL]:
+            if status in [StoreStatus.NONE, StoreStatus.CHUNK_PREFILL]:
+                continue
+            elif status in [StoreStatus.SUFFIX_PREFILL]:
                 seq_len = seq_lens[seq_data_idx]
             else:
                 seq_len = seq_data.get_len()
-            if status == StoreStatus.NONE:
-                continue
-            elif status == StoreStatus.DECODE:
-                if seq_len % engine.chunk_size != 0:
-                    continue
+                if status == StoreStatus.DECODE:
+                    if seq_len % engine.chunk_size != 0:
+                        continue
             current_tokens = torch.tensor(seq_data.get_token_ids()[:seq_len], device="cpu")
             vllm_block_size = cache_config.block_size
             skip_leading_tokens = engine.lookup(current_tokens)
@@ -568,7 +568,7 @@ def lmcache_retrieve_kv(
             # is batched with any decode or other chunked prefills.
             # This is not done as I assume the performance benefit is marginal.
             if retrieve_status == RetrieveStatus.CHUNK_PREFILL:
-                if num_computed_tokens != vllm_num_required_tokens:
+                if num_computed_tokens != total_seq_len:
                     return model_input, False
             else:
                 # Avoid the error when prefix is exactly the same as the retrieved

--- a/lmcache_vllm/vllm_adapter.py
+++ b/lmcache_vllm/vllm_adapter.py
@@ -274,18 +274,9 @@ def lmcache_should_retrieve(
             assert len(seq_lens) == 1
             return RetrieveStatus.CHUNK_PREFILL
         
-        '''
-        # Check whether the current prefill chunk is the last one
-        key = list(model_input.sampling_metadata.seq_groups[0].seq_data.keys())[0]
-        seq_data = model_input.sampling_metadata.seq_groups[0].seq_data[key]
-        prompt_tokens = seq_data.prompt_token_ids
-        if model_input.seq_lens[0] != len(prompt_tokens):
-            #TODO(Jiayi): We should support this as well
-            return RetrieveStatus.CHUNK_PREFILL_LAST
-        '''
-        return RetrieveStatus.PREFILL
-
-    # for disaggregated prefilling: allow bypassing model execution
+        # `<` means chunked prefill is batched with decode
+        if len(selected_token_indices) == len(seq_lens):
+            return RetrieveStatus.PREFILL
 
     return RetrieveStatus.NONE
 
@@ -349,22 +340,26 @@ def lmcache_should_store(
 
     if is_all_prefill_run:
         selected_token_indices = model_input.sampling_metadata.selected_token_indices
-        if len(selected_token_indices) == 0:
-            # There should only be 1 chunk in chunked prefill
-            assert len(seq_lens) == 1
-            return [StoreStatus.CHUNK_PREFILL]
-        
         seq_group_metadata_list = model_input.seq_group_metadata_list
-        idx = 0
+        seq_data_idx = 0
+        selected_token_indices_idx = 0
         for seq_group_idx, seq_group_metadata in enumerate(seq_group_metadata_list):
+            
+            # TODO(Jiayi): Figure out scenarios (other than chunk prefill) 
+            # where `do_sample`` is False 
+            if not seq_group_metadata.do_sample:
+                store_status[seq_data_idx] = StoreStatus.CHUNK_PREFILL
+                seq_data_idx += 1 
+                continue
             for seqid, seq_data in seq_group_metadata.seq_data.items():
-                if seq_data.get_len()-1 != selected_token_indices[idx]:
+                if seq_data.get_len()-1 != selected_token_indices[selected_token_indices_idx]:
                     # last chunk in chunk prefill
                     # or prefix already hit in retrieve
-                    store_status[idx] = StoreStatus.SUFFIX_PREFILL
+                    store_status[seq_data_idx] = StoreStatus.SUFFIX_PREFILL
                 else:
-                    store_status[idx] = StoreStatus.PREFILL
-                idx += 1
+                    store_status[seq_data_idx] = StoreStatus.PREFILL
+                seq_data_idx += 1
+                selected_token_indices_idx += 1
         return store_status
         
 

--- a/lmcache_vllm/vllm_injection.py
+++ b/lmcache_vllm/vllm_injection.py
@@ -47,7 +47,6 @@ def new_execute_model(
         logger.info(f"KV cache retrieving mode: {retrieve_status}")
         model_input, is_skip = lmcache_retrieve_kv(
             self.model, self.model_config.model, model_input, kv_caches, retrieve_status)
-
         if is_skip:
             logger.debug("Prefill is entirely skipped")
             


### PR DESCRIPTION
Some offline benchmarking:
(1) vllm + chunk prefill: 6.2s
(2) vllm + chunk prefill + lmcache: 10.7s (1st request), 1.3s (2nd), 1.3s (3rd).

@Shaoting-Feng Please test the e2e results as well.