### PR TITLE
Drop special tokens.

### DIFF
--- a/lmcache_vllm/blend_adapter.py
+++ b/lmcache_vllm/blend_adapter.py
@@ -30,7 +30,7 @@ class ReqId2Indices:
 global_req_id2indices = ReqId2Indices()
 
 # TODO: need to load the special token and recompute ratio from configuration
-TEMP_SPT = [422, 422]
+TEMP_SPT = torch.tensor([422, 422], dtype = torch.int, device = "cpu")
 RECOMP_RATIO = 0.15
 MINIMUM_TOKENS_TO_ENABLE_BLENDING = 256
 global_blend_retriever = None

--- a/lmcache_vllm/blend_adapter.py
+++ b/lmcache_vllm/blend_adapter.py
@@ -15,6 +15,9 @@ from lmcache_vllm.lmcache_utils import ENGINE_NAME
 logger = init_logger(__name__)
 
 class ReqId2Indices:
+    """The class for cacheblend indices.
+    Map request_id to indices to split the prompt.
+    """
     def __init__(self):
         self._map_dict = {}
     def add_request(self, request_id, indices):
@@ -90,6 +93,16 @@ def init_cacheblend_retriever():
 # MAIN FUNCTIONS
 
 def drop_blend_spt(request_id, prompt: List[int]) -> List[int]:
+    """Drop the SPT tokens from the prompt and return the new prompt.
+    Also stores the indices for later retrieval.
+    :param request_id: The request id in sequence group.
+
+    :param prompt: The input prompt after tokenization.
+    :type prompt: List[int]
+
+    :return: The new prompt after dropping the SPT tokens.
+    :rtype: List[int]
+    """
     if global_blend_retriever is None:
         init_cacheblend_retriever()
     new_prompt, indices = global_blend_retriever.drop_spt_and_get_indices(prompt)
@@ -97,10 +110,20 @@ def drop_blend_spt(request_id, prompt: List[int]) -> List[int]:
     return new_prompt
 
 def get_blend_indices(request_id) -> List[int]:
+    """Get the indices after split for the request id.
+    :param request_id: The request id in sequence group.
+
+    :return: The indices for the request id.
+    :rtype: List[int]
+    """
     indices = global_req_id2indices.get_request(request_id)
     return indices if indices is not None else []
 
 def remove_request_id_indices(request_id):
+    """Remove stored indices of request id.
+    Called when a sequence group is finished.
+    :param request_id: The request id in sequence group.
+    """
     global_req_id2indices.delete_request(request_id)
 
 def combine_input_prompt_chunks(
@@ -201,6 +224,13 @@ def attach_blend_prompt_indices(
         seq_group_metadata_list: List[SequenceGroupMetadata],
         attn_metadata: AttentionMetadata,
     ):
+    """Attach the prompts and indices after split to blend_metadata in attn_metadata.
+    :param seq_group_metadata_list: The list of sequence group metadata.
+    :type seq_group_metadata_list: List[SequenceGroupMetadata]
+
+    :param attn_metadata: The attention metadata.
+    :type attn_metadata: AttentionMetadata
+    """
     assert not hasattr(attn_metadata, "blend_metadata")
     blend_metadata = BlendMetadata(0, None, None, None, [], [], None, None)
     setattr(attn_metadata, "blend_metadata", blend_metadata)

--- a/lmcache_vllm/blend_adapter.py
+++ b/lmcache_vllm/blend_adapter.py
@@ -30,7 +30,7 @@ class ReqId2Indices:
 global_req_id2indices = ReqId2Indices()
 
 # TODO: need to load the special token and recompute ratio from configuration
-TEMP_SPT = torch.tensor([422, 422], dtype = torch.int, device = "cpu")
+TEMP_SPT = [422, 422]
 RECOMP_RATIO = 0.15
 MINIMUM_TOKENS_TO_ENABLE_BLENDING = 256
 global_blend_retriever = None
@@ -194,7 +194,7 @@ def process_new_request(
     for tp in blend_prompt_indices:
         prompt_list.append(tp[0])
         indices_list.append(tp[1])
-    task = global_blend_retriever.segmented_new_request(prompt_list, indices_list)
+    task = global_blend_retriever.new_request(prompt_list, indices_list)
 
     executor = CacheBlendImpl(RECOMP_RATIO)
     blend_metadata = BlendMetadata(0, positions, task, executor, None, None)

--- a/lmcache_vllm/blend_adapter.py
+++ b/lmcache_vllm/blend_adapter.py
@@ -31,8 +31,6 @@ global_req_id2indices = ReqId2Indices()
 
 # TODO: need to load the special token and recompute ratio from configuration
 TEMP_SPT = [422, 422]
-RECOMP_RATIO = 0.15
-MINIMUM_TOKENS_TO_ENABLE_BLENDING = 256
 global_blend_retriever = None
 g_manually_disabled = False
 
@@ -159,7 +157,8 @@ def should_process_request(
     if is_profile_run:
         return False
 
-    # TODO: make this "256" be configurable
+    cache_engine = LMCacheEngineBuilder.get(ENGINE_NAME)
+    MINIMUM_TOKENS_TO_ENABLE_BLENDING = cache_engine.config.blend_min_tokens
     if len(input_ids) < MINIMUM_TOKENS_TO_ENABLE_BLENDING:
         return False
 
@@ -197,6 +196,7 @@ def process_new_request(
         attn_metadata.blend_metadata.request_prompt_list, 
         attn_metadata.blend_metadata.prompt_indices_list
     )
+    RECOMP_RATIO = cache_engine.config.blend_recompute_ratio
     executor = CacheBlendImpl(RECOMP_RATIO)
     attn_metadata.blend_metadata.positions = positions
     attn_metadata.blend_metadata.retrieval_task = task

--- a/lmcache_vllm/blend_adapter.py
+++ b/lmcache_vllm/blend_adapter.py
@@ -14,22 +14,21 @@ from lmcache_vllm.lmcache_utils import ENGINE_NAME
 
 logger = init_logger(__name__)
 
+# NOTE: With openai apiserver, it is possible to 
+# have duplicated request_id if very unlucky.
 class ReqId2Indices:
     def __init__(self):
         self._map_dict = {}
     def add_request(self, request_id, indices):
-        assert request_id not in self._map_dict
         self._map_dict[request_id] = indices
     def get_request(self, request_id):
-        assert request_id in self._map_dict
-        return self._map_dict[request_id]
+        return self._map_dict.get(request_id, None)
     def delete_request(self, request_id):
-        assert request_id in self._map_dict
-        del self._map_dict[request_id]
+        self._map_dict.pop(request_id, None)
     
 global_req_id2indices = ReqId2Indices()
 
-# TODO: need to load the special token and recompute ratio from configuration
+# TODO: Special token text and token_id should depend on models.
 TEMP_SPT = [422, 422]
 global_blend_retriever = None
 g_manually_disabled = False
@@ -102,8 +101,18 @@ def drop_blend_spt(request_id, prompt: List[int]) -> List[int]:
 def get_blend_indices(request_id, len_of_prompt: int) -> List[int]:
     # NOTE: Always adjust the last index to the end of the request.
     indices = global_req_id2indices.get_request(request_id)
-    indices[-1] = len_of_prompt
-    return indices
+    if indices is None:
+        logger.warning("indices is None, possible due to duplicated request_id")
+        return [0, len_of_prompt]
+    assert len(indices) >= 2
+    assert indices[0] == 0
+    if indices[-1] > len_of_prompt:
+        # Only possible when duplicated request_id, resulting in wrong indices.
+        logger.warning("indices not matching prompt length, possible due to duplicated request_id")
+        return [0, len_of_prompt]
+    else:
+        indices[-1] = len_of_prompt
+        return indices
 
 def remove_request_id_indices(request_id):
     global_req_id2indices.delete_request(request_id)

--- a/lmcache_vllm/blend_adapter.py
+++ b/lmcache_vllm/blend_adapter.py
@@ -10,12 +10,27 @@ from lmcache.logging import init_logger
 
 from vllm.attention import AttentionMetadata
 
-from lmcache_vllm.vllm_adapter import ENGINE_NAME
+from lmcache_vllm.lmcache_utils import ENGINE_NAME
 
 logger = init_logger(__name__)
 
+class ReqId2Indices:
+    def __init__(self):
+        self._map_dict = {}
+    def add_request(self, request_id, indices):
+        assert request_id not in self._map_dict
+        self._map_dict[request_id] = indices
+    def get_request(self, request_id):
+        assert request_id in self._map_dict
+        return self._map_dict[request_id]
+    def delete_request(self, request_id):
+        assert request_id in self._map_dict
+        del self._map_dict[request_id]
+    
+global_req_id2indices = ReqId2Indices()
+
 # TODO: need to load the special token and recompute ratio from configuration
-TEMP_SPT = torch.tensor([422, 422], dtype = torch.int, device = "cpu")
+TEMP_SPT = [422, 422]
 RECOMP_RATIO = 0.15
 MINIMUM_TOKENS_TO_ENABLE_BLENDING = 256
 global_blend_retriever = None
@@ -76,6 +91,24 @@ def init_cacheblend_retriever():
 
 
 # MAIN FUNCTIONS
+
+def drop_blend_spt(request_id, prompt: List[int]) -> List[int]:
+    if global_blend_retriever is None:
+        init_cacheblend_retriever()
+    new_prompt, indices = global_blend_retriever.drop_spt_and_get_indices(prompt)
+    global_req_id2indices.add_request(request_id, indices)
+    return new_prompt
+
+def get_blend_indices(request_id, len_of_prompt: int) -> List[int]:
+    # NOTE: Always adjust the last index to the end of the request.
+    indices = global_req_id2indices.get_request(request_id)
+    indices[-1] = len_of_prompt
+    return indices
+
+# TODO: When to remove the indices, should remove when sequence group is removed.
+
+def remove_request_id_indices(request_id):
+    global_req_id2indices.delete_request(request_id)
 
 def combine_input_prompt_chunks(
         prompt_chunks: List[str],
@@ -156,7 +189,13 @@ def process_new_request(
     global global_blend_retriever
     if global_blend_retriever is None:
         init_cacheblend_retriever()
-    task = global_blend_retriever.new_request(input_ids.cpu(), attn_metadata.query_start_loc)
+    prompt_list = []
+    indices_list = []
+    blend_prompt_indices = attn_metadata.blend_prompt_indices
+    for tp in blend_prompt_indices:
+        prompt_list.append(tp[0])
+        indices_list.append(tp[1])
+    task = global_blend_retriever.new_request(prompt_list, indices_list)
 
     executor = CacheBlendImpl(RECOMP_RATIO)
     blend_metadata = BlendMetadata(0, positions, task, executor, None, None)

--- a/lmcache_vllm/blend_adapter.py
+++ b/lmcache_vllm/blend_adapter.py
@@ -105,7 +105,6 @@ def get_blend_indices(request_id, len_of_prompt: int) -> List[int]:
     indices[-1] = len_of_prompt
     return indices
 
-# TODO: When to remove the indices, should remove when sequence group is removed.
 
 def remove_request_id_indices(request_id):
     global_req_id2indices.delete_request(request_id)
@@ -195,7 +194,7 @@ def process_new_request(
     for tp in blend_prompt_indices:
         prompt_list.append(tp[0])
         indices_list.append(tp[1])
-    task = global_blend_retriever.new_request(prompt_list, indices_list)
+    task = global_blend_retriever.segmented_new_request(prompt_list, indices_list)
 
     executor = CacheBlendImpl(RECOMP_RATIO)
     blend_metadata = BlendMetadata(0, positions, task, executor, None, None)

--- a/lmcache_vllm/blend_adapter.py
+++ b/lmcache_vllm/blend_adapter.py
@@ -9,13 +9,28 @@ from lmcache.blend.interfaces import BlendRetrieverTask, BlendExecutor
 from lmcache.logging import init_logger
 
 from vllm.attention import AttentionMetadata
-
-from lmcache_vllm.vllm_adapter import ENGINE_NAME
+from vllm.sequence import SequenceGroupMetadata
+from lmcache_vllm.lmcache_utils import ENGINE_NAME
 
 logger = init_logger(__name__)
 
+class ReqId2Indices:
+    def __init__(self):
+        self._map_dict = {}
+    def add_request(self, request_id, indices):
+        assert request_id not in self._map_dict
+        self._map_dict[request_id] = indices
+    def get_request(self, request_id):
+        assert request_id in self._map_dict
+        return self._map_dict[request_id]
+    def delete_request(self, request_id):
+        assert request_id in self._map_dict
+        del self._map_dict[request_id]
+    
+global_req_id2indices = ReqId2Indices()
+
 # TODO: need to load the special token and recompute ratio from configuration
-TEMP_SPT = torch.tensor([422, 422], dtype = torch.int, device = "cpu")
+TEMP_SPT = [422, 422]
 RECOMP_RATIO = 0.15
 MINIMUM_TOKENS_TO_ENABLE_BLENDING = 256
 global_blend_retriever = None
@@ -51,6 +66,8 @@ class BlendMetadata:
     positions: torch.Tensor
     retrieval_task: BlendRetrieverTask
     blend_executor: BlendExecutor
+    request_prompt_list: List[torch.Tensor]
+    prompt_indices_list: List[List[int]]
     selected_token_indices: torch.Tensor
     original_query_start_loc: torch.Tensor
 
@@ -76,6 +93,23 @@ def init_cacheblend_retriever():
 
 
 # MAIN FUNCTIONS
+
+def drop_blend_spt(request_id, prompt: List[int]) -> List[int]:
+    if global_blend_retriever is None:
+        init_cacheblend_retriever()
+    new_prompt, indices = global_blend_retriever.drop_spt_and_get_indices(prompt)
+    global_req_id2indices.add_request(request_id, indices)
+    return new_prompt
+
+def get_blend_indices(request_id, len_of_prompt: int) -> List[int]:
+    # NOTE: Always adjust the last index to the end of the request.
+    indices = global_req_id2indices.get_request(request_id)
+    indices[-1] = len_of_prompt
+    return indices
+
+
+def remove_request_id_indices(request_id):
+    global_req_id2indices.delete_request(request_id)
 
 def combine_input_prompt_chunks(
         prompt_chunks: List[str],
@@ -145,10 +179,11 @@ def process_new_request(
     """Creates the cacheblend related stuff and put that into the attn metadata
     """
     if not should_process_request(input_ids, attn_metadata, kv_caches):
+        if hasattr(attn_metadata, "blend_metadata"):
+            delattr(attn_metadata, "blend_metadata")
         return attn_metadata
-
     cache_engine = LMCacheEngineBuilder.get(ENGINE_NAME)
-
+    
     if cache_engine is None:
         logger.error("Cannot initialize cache blend logic because LMCacheEngine is not initialized")
         raise RuntimeError("Cannot initialize cache blend logic because LMCacheEngine is not initialized")
@@ -156,12 +191,39 @@ def process_new_request(
     global global_blend_retriever
     if global_blend_retriever is None:
         init_cacheblend_retriever()
-    task = global_blend_retriever.new_request(input_ids.cpu(), attn_metadata.query_start_loc)
-
+    
+    assert hasattr(attn_metadata, "blend_metadata")
+    task = global_blend_retriever.new_request(
+        attn_metadata.blend_metadata.request_prompt_list, 
+        attn_metadata.blend_metadata.prompt_indices_list
+    )
     executor = CacheBlendImpl(RECOMP_RATIO)
-    blend_metadata = BlendMetadata(0, positions, task, executor, None, None)
-    setattr(attn_metadata, "blend_metadata", blend_metadata)
+    attn_metadata.blend_metadata.positions = positions
+    attn_metadata.blend_metadata.retrieval_task = task
+    attn_metadata.blend_metadata.blend_executor = executor
     return attn_metadata
+
+def attach_blend_prompt_indices(
+        seq_group_metadata_list: List[SequenceGroupMetadata],
+        attn_metadata: AttentionMetadata,
+    ):
+    assert not hasattr(attn_metadata, "blend_metadata")
+    blend_metadata = BlendMetadata(0, None, None, None, [], [], None, None)
+    setattr(attn_metadata, "blend_metadata", blend_metadata)
+    seq_lens = attn_metadata.seq_lens
+    seq_data_idx = 0
+    for seq_group_metadata in seq_group_metadata_list:
+        for seqid, seq_data in seq_group_metadata.seq_data.items():
+            seq_len = seq_lens[seq_data_idx]
+            if seq_group_metadata.block_tables is not None:
+                indices = get_blend_indices(seq_group_metadata.request_id, seq_len)
+            else:
+                indices = [0, seq_len]
+            attn_metadata.blend_metadata.request_prompt_list.append(torch.tensor(
+                seq_data.get_token_ids()[:seq_len], device="cpu"))
+            attn_metadata.blend_metadata.prompt_indices_list.append(indices)
+            seq_data_idx += 1
+    assert seq_data_idx == len(seq_lens)
 
 
 def do_blend(

--- a/lmcache_vllm/blend_adapter.py
+++ b/lmcache_vllm/blend_adapter.py
@@ -14,8 +14,6 @@ from lmcache_vllm.lmcache_utils import ENGINE_NAME
 
 logger = init_logger(__name__)
 
-# NOTE: With openai apiserver, it is possible to 
-# have duplicated request_id if very unlucky.
 class ReqId2Indices:
     def __init__(self):
         self._map_dict = {}
@@ -98,21 +96,9 @@ def drop_blend_spt(request_id, prompt: List[int]) -> List[int]:
     global_req_id2indices.add_request(request_id, indices)
     return new_prompt
 
-def get_blend_indices(request_id, len_of_prompt: int) -> List[int]:
-    # NOTE: Always adjust the last index to the end of the request.
+def get_blend_indices(request_id) -> List[int]:
     indices = global_req_id2indices.get_request(request_id)
-    if indices is None:
-        logger.warning("indices is None, possible due to duplicated request_id")
-        return [0, len_of_prompt]
-    assert len(indices) >= 2
-    assert indices[0] == 0
-    if indices[-1] > len_of_prompt:
-        # Only possible when duplicated request_id, resulting in wrong indices.
-        logger.warning("indices not matching prompt length, possible due to duplicated request_id")
-        return [0, len_of_prompt]
-    else:
-        indices[-1] = len_of_prompt
-        return indices
+    return indices if indices is not None else []
 
 def remove_request_id_indices(request_id):
     global_req_id2indices.delete_request(request_id)
@@ -224,9 +210,9 @@ def attach_blend_prompt_indices(
         for seqid, seq_data in seq_group_metadata.seq_data.items():
             seq_len = seq_lens[seq_data_idx]
             if seq_group_metadata.block_tables is not None:
-                indices = get_blend_indices(seq_group_metadata.request_id, seq_len)
+                indices = get_blend_indices(seq_group_metadata.request_id)
             else:
-                indices = [0, seq_len]
+                indices = []
             attn_metadata.blend_metadata.request_prompt_list.append(torch.tensor(
                 seq_data.get_token_ids()[:seq_len], device="cpu"))
             attn_metadata.blend_metadata.prompt_indices_list.append(indices)

--- a/lmcache_vllm/blend_adapter.py
+++ b/lmcache_vllm/blend_adapter.py
@@ -9,7 +9,7 @@ from lmcache.blend.interfaces import BlendRetrieverTask, BlendExecutor
 from lmcache.logging import init_logger
 
 from vllm.attention import AttentionMetadata
-
+from vllm.sequence import SequenceGroupMetadata
 from lmcache_vllm.lmcache_utils import ENGINE_NAME
 
 logger = init_logger(__name__)
@@ -66,6 +66,8 @@ class BlendMetadata:
     positions: torch.Tensor
     retrieval_task: BlendRetrieverTask
     blend_executor: BlendExecutor
+    request_prompt_list: List[torch.Tensor]
+    prompt_indices_list: List[List[int]]
     selected_token_indices: torch.Tensor
     original_query_start_loc: torch.Tensor
 
@@ -177,10 +179,11 @@ def process_new_request(
     """Creates the cacheblend related stuff and put that into the attn metadata
     """
     if not should_process_request(input_ids, attn_metadata, kv_caches):
+        if hasattr(attn_metadata, "blend_metadata"):
+            delattr(attn_metadata, "blend_metadata")
         return attn_metadata
-
     cache_engine = LMCacheEngineBuilder.get(ENGINE_NAME)
-
+    
     if cache_engine is None:
         logger.error("Cannot initialize cache blend logic because LMCacheEngine is not initialized")
         raise RuntimeError("Cannot initialize cache blend logic because LMCacheEngine is not initialized")
@@ -188,18 +191,39 @@ def process_new_request(
     global global_blend_retriever
     if global_blend_retriever is None:
         init_cacheblend_retriever()
-    prompt_list = []
-    indices_list = []
-    blend_prompt_indices = attn_metadata.blend_prompt_indices
-    for tp in blend_prompt_indices:
-        prompt_list.append(tp[0])
-        indices_list.append(tp[1])
-    task = global_blend_retriever.new_request(prompt_list, indices_list)
-
+    
+    assert hasattr(attn_metadata, "blend_metadata")
+    task = global_blend_retriever.new_request(
+        attn_metadata.blend_metadata.request_prompt_list, 
+        attn_metadata.blend_metadata.prompt_indices_list
+    )
     executor = CacheBlendImpl(RECOMP_RATIO)
-    blend_metadata = BlendMetadata(0, positions, task, executor, None, None)
-    setattr(attn_metadata, "blend_metadata", blend_metadata)
+    attn_metadata.blend_metadata.positions = positions
+    attn_metadata.blend_metadata.retrieval_task = task
+    attn_metadata.blend_metadata.blend_executor = executor
     return attn_metadata
+
+def attach_blend_prompt_indices(
+        seq_group_metadata_list: List[SequenceGroupMetadata],
+        attn_metadata: AttentionMetadata,
+    ):
+    assert not hasattr(attn_metadata, "blend_metadata")
+    blend_metadata = BlendMetadata(0, None, None, None, [], [], None, None)
+    setattr(attn_metadata, "blend_metadata", blend_metadata)
+    seq_lens = attn_metadata.seq_lens
+    seq_data_idx = 0
+    for seq_group_metadata in seq_group_metadata_list:
+        for seqid, seq_data in seq_group_metadata.seq_data.items():
+            seq_len = seq_lens[seq_data_idx]
+            if seq_group_metadata.block_tables is not None:
+                indices = get_blend_indices(seq_group_metadata.request_id, seq_len)
+            else:
+                indices = [0, seq_len]
+            attn_metadata.blend_metadata.request_prompt_list.append(torch.tensor(
+                seq_data.get_token_ids()[:seq_len], device="cpu"))
+            attn_metadata.blend_metadata.prompt_indices_list.append(indices)
+            seq_data_idx += 1
+    assert seq_data_idx == len(seq_lens)
 
 
 def do_blend(

--- a/lmcache_vllm/lmcache_utils.py
+++ b/lmcache_vllm/lmcache_utils.py
@@ -1,0 +1,1 @@
+ENGINE_NAME = "vllm-instance"

--- a/lmcache_vllm/vllm_adapter.py
+++ b/lmcache_vllm/vllm_adapter.py
@@ -23,11 +23,12 @@ from lmcache.logging import init_logger
 from lmcache.cache_engine import LMCacheEngine, LMCacheEngineBuilder
 from lmcache.config import LMCacheEngineConfig, LMCacheEngineMetadata
 from lmcache.utils import _lmcache_nvtx_annotate
-
+from lmcache_vllm.lmcache_utils import ENGINE_NAME
+from lmcache_vllm.blend_adapter import drop_blend_spt
 
 logger = init_logger(__name__)
 
-ENGINE_NAME = "vllm-instance"
+
 LMCACHE_CUDA_STREAM = torch.cuda.Stream()
 
 TORCH_DTYPE_TO_STR_DTYPE = {
@@ -138,6 +139,13 @@ def lmcache_get_config() -> LMCacheEngineConfig:
     lmcache_get_config.cached_config = config
     return config
 
+def lmcache_blend_drop_spt(request_id, prompt: List[int]) -> List[int]:
+    engine = LMCacheEngineBuilder.get(ENGINE_NAME)
+    if engine is None:
+        return prompt
+    if not engine.config.enable_blending:
+        return prompt
+    return drop_blend_spt(request_id, prompt)
 
 def init_lmcache_engine(
         model_config: ModelConfig,

--- a/lmcache_vllm/vllm_adapter.py
+++ b/lmcache_vllm/vllm_adapter.py
@@ -24,7 +24,7 @@ from lmcache.cache_engine import LMCacheEngine, LMCacheEngineBuilder
 from lmcache.config import LMCacheEngineConfig, LMCacheEngineMetadata
 from lmcache.utils import _lmcache_nvtx_annotate
 from lmcache_vllm.lmcache_utils import ENGINE_NAME
-from lmcache_vllm.blend_adapter import drop_blend_spt
+from lmcache_vllm.blend_adapter import drop_blend_spt, remove_request_id_indices
 
 logger = init_logger(__name__)
 
@@ -146,6 +146,15 @@ def lmcache_blend_drop_spt(request_id, prompt: List[int]) -> List[int]:
     if not engine.config.enable_blending:
         return prompt
     return drop_blend_spt(request_id, prompt)
+
+def lmcache_remove_request_id_indices(request_id):
+    engine = LMCacheEngineBuilder.get(ENGINE_NAME)
+    if engine is None:
+        return
+    if not engine.config.enable_blending:
+        return
+    remove_request_id_indices(request_id)
+    
 
 def init_lmcache_engine(
         model_config: ModelConfig,

--- a/lmcache_vllm/vllm_adapter.py
+++ b/lmcache_vllm/vllm_adapter.py
@@ -176,6 +176,8 @@ def init_lmcache_engine(
     head_size = model_config.get_head_size()
     kv_shape = (num_layer, 2, chunk_size, num_kv_head, head_size)
     
+    # Change current device.
+    torch.cuda.device(parallel_config.rank)
     metadata = LMCacheEngineMetadata(
             model_config.model,
             parallel_config.world_size,

--- a/lmcache_vllm/vllm_adapter.py
+++ b/lmcache_vllm/vllm_adapter.py
@@ -141,10 +141,8 @@ def lmcache_get_config() -> LMCacheEngineConfig:
 
 def lmcache_blend_drop_spt(request_id, prompt: List[int]) -> List[int]:
     engine = LMCacheEngineBuilder.get(ENGINE_NAME)
-    if engine is None:
-        return prompt
-    if not engine.config.enable_blending:
-        return prompt
+    assert engine is not None
+    assert engine.config.enable_blending
     return drop_blend_spt(request_id, prompt)
 
 def lmcache_remove_request_id_indices(request_id):

--- a/lmcache_vllm/vllm_adapter.py
+++ b/lmcache_vllm/vllm_adapter.py
@@ -23,11 +23,12 @@ from lmcache.logging import init_logger
 from lmcache.cache_engine import LMCacheEngine, LMCacheEngineBuilder
 from lmcache.config import LMCacheEngineConfig, LMCacheEngineMetadata
 from lmcache.utils import _lmcache_nvtx_annotate
-
+from lmcache_vllm.lmcache_utils import ENGINE_NAME
+from lmcache_vllm.blend_adapter import drop_blend_spt
 
 logger = init_logger(__name__)
 
-ENGINE_NAME = "vllm-instance"
+
 LMCACHE_CUDA_STREAM = torch.cuda.Stream()
 
 TORCH_DTYPE_TO_STR_DTYPE = {
@@ -138,6 +139,13 @@ def lmcache_get_config() -> LMCacheEngineConfig:
     lmcache_get_config.cached_config = config
     return config
 
+def lmcache_blend_drop_spt(request_id, prompt: List[int]) -> List[int]:
+    engine = LMCacheEngineBuilder.get(ENGINE_NAME)
+    if engine is None:
+        return prompt
+    if not engine.config.enable_blending:
+        return prompt
+    return drop_blend_spt(request_id, prompt)
 
 def init_lmcache_engine(
         model_config: ModelConfig,
@@ -767,4 +775,3 @@ def build_partial_prefill_input(
     )
 
     return rebuilt_model_input
-

--- a/lmcache_vllm/vllm_injection.py
+++ b/lmcache_vllm/vllm_injection.py
@@ -1,15 +1,12 @@
 """
 This version works with vllm-0.6.1.post2 and 0.6.2
 """
-from functools import wraps
 import torch
-import os
 import asyncio
 import dataclasses
 from dataclasses import fields
 from typing import Optional, List, Set, Dict, Any
 
-import vllm.entrypoints.openai.serving_engine
 from vllm.multimodal import MultiModalInputs
 from vllm.lora.request import LoRARequest
 from vllm.worker.model_runner_base import dump_input_when_exception
@@ -25,7 +22,6 @@ from lmcache_vllm.blend_adapter import attach_blend_prompt_indices
 
 from lmcache_vllm.models.llama import inject_llama
 from lmcache_vllm.attention.flash_attn import inject_flash_attn
-import vllm.worker.model_runner_base
 
 from lmcache.logging import init_logger
 logger = init_logger(__name__)

--- a/lmcache_vllm/vllm_injection.py
+++ b/lmcache_vllm/vllm_injection.py
@@ -16,8 +16,9 @@ from vllm.distributed import get_pp_group
 from lmcache_vllm.vllm_adapter import (lmcache_get_config,
         init_lmcache_engine, lmcache_should_store, lmcache_should_retrieve,
         lmcache_store_kv, lmcache_retrieve_kv, close_lmcache_engine,
-        broadcast_seq_group_metadata, StoreStatus, RetrieveStatus,
+        broadcast_seq_group_metadata, lmcache_blend_drop_spt, StoreStatus, RetrieveStatus,
         SUPPORTED_MODELS)
+from lmcache_vllm.blend_adapter import get_blend_indices, remove_request_id_indices
 
 from lmcache_vllm.models.llama import inject_llama
 from lmcache_vllm.attention.flash_attn import inject_flash_attn
@@ -244,7 +245,7 @@ def _new_tokenize_prompt(
                             prompt=prompt,
                             lora_request=lora_request)
     
-    return res
+    return lmcache_blend_drop_spt(request_id, res)
 
 async def _new_tokenize_prompt_async(
     self,
@@ -265,7 +266,7 @@ async def _new_tokenize_prompt_async(
                                         prompt=prompt,
                                         lora_request=lora_request)
     
-    return res
+    return lmcache_blend_drop_spt(request_id, res)
 
 def new_log_task_completion(task: asyncio.Task,
                             error_callback) -> None:
@@ -314,6 +315,42 @@ def wrap_prepare_model_input(
     # at the last stage of pipeline parallelism stages.
     return dataclasses.replace(model_input, seq_group_metadata_list=seq_group_metadata_list)
 
+original_prepare_model_input_tensors = None
+def wrap_prepare_model_input_tensors(
+        self,
+        seq_group_metadata_list,
+        finished_requests_ids: Optional[List[str]] = None
+    ):
+    model_input = original_prepare_model_input_tensors(self,
+        seq_group_metadata_list, finished_requests_ids)
+    attn_metadata = model_input.attn_metadata
+    if attn_metadata is not None:
+        if lmcache_get_config().enable_blending:
+            assert not hasattr(attn_metadata, "blend_prompt_indices")
+            setattr(attn_metadata, "blend_prompt_indices", [])
+            seq_lens = attn_metadata.seq_lens
+            seq_data_idx = 0
+            for seq_group_metadata in seq_group_metadata_list:
+                for seqid, seq_data in seq_group_metadata.seq_data.items():
+                    seq_len = seq_lens[seq_data_idx]
+                    if seq_group_metadata.block_tables is not None:
+                        indices = get_blend_indices(seq_group_metadata.request_id, seq_len)
+                    else:
+                        indices = [0, seq_len]
+                    attn_metadata.blend_prompt_indices.append((torch.tensor(
+                        seq_data.get_token_ids()[:seq_len], device="cpu"), indices))
+                    seq_data_idx += 1
+            assert seq_data_idx == len(seq_lens)
+    return model_input
+
+def new_free_finished_seqs(self, seq_group) -> None:
+    """Free finished seqs in a sequence group."""
+    for seq in seq_group.get_seqs():
+        if seq.is_finished():
+            self.free_seq(seq)
+    if seq_group.is_finished():
+        remove_request_id_indices(seq_group.request_id)
+
 def InitLMCacheEnvironment() -> None:
     """Initialize the LMCache environment.
     """
@@ -328,6 +365,13 @@ def InitLMCacheEnvironment() -> None:
     global original_prepare_model_input
     original_prepare_model_input = vllm.worker.model_runner.ModelRunner.prepare_model_input
     vllm.worker.model_runner.ModelRunner.prepare_model_input = wrap_prepare_model_input
+
+    global original_prepare_model_input_tensors
+    original_prepare_model_input_tensors = vllm.worker.model_runner.ModelRunner._prepare_model_input_tensors
+    vllm.worker.model_runner.ModelRunner._prepare_model_input_tensors = wrap_prepare_model_input_tensors
+
+    import vllm.core.scheduler
+    vllm.core.scheduler.Scheduler._free_finished_seqs = new_free_finished_seqs
     
     import vllm
     vllm.inputs.preprocess.InputPreprocessor._tokenize_prompt = _new_tokenize_prompt

--- a/lmcache_vllm/vllm_injection.py
+++ b/lmcache_vllm/vllm_injection.py
@@ -9,6 +9,7 @@ import dataclasses
 from dataclasses import fields
 from typing import Optional, List, Set, Dict, Any
 
+import vllm.entrypoints.openai.serving_engine
 from vllm.multimodal import MultiModalInputs
 from vllm.lora.request import LoRARequest
 from vllm.worker.model_runner_base import dump_input_when_exception
@@ -244,11 +245,10 @@ def _new_tokenize_prompt(
     prompt = _patch_padding_space(tokenizer_id, prompt)
     # Jiayi: Patch ends here
 
-    res = tokenizer.encode(request_id=request_id,
+    return tokenizer.encode(request_id=request_id,
                             prompt=prompt,
                             lora_request=lora_request)
     
-    return lmcache_blend_drop_spt(request_id, res)
 
 async def _new_tokenize_prompt_async(
     self,
@@ -265,11 +265,10 @@ async def _new_tokenize_prompt_async(
     prompt = _patch_padding_space(tokenizer_id, prompt)
     # Jiayi: Patch ends here
 
-    res = await tokenizer.encode_async(request_id=request_id,
+    return await tokenizer.encode_async(request_id=request_id,
                                         prompt=prompt,
                                         lora_request=lora_request)
     
-    return lmcache_blend_drop_spt(request_id, res)
 
 def new_log_task_completion(task: asyncio.Task,
                             error_callback) -> None:
@@ -377,6 +376,70 @@ def new_from_broadcasted_tensor_dict_with_sampling(
         return cls(**tensor_dict)
 
 
+original_extract_prompt_components = None
+original_extract_prompt_components_async = None
+
+def new_extract_prompt_components(self,
+                                  inputs,
+                                  request_id,
+                                  lora_request = None):
+    prompt, prompt_token_ids, multi_modal_data = original_extract_prompt_components(self, inputs, request_id, lora_request)
+    prompt_token_ids = lmcache_blend_drop_spt(request_id, prompt_token_ids)
+    return prompt, prompt_token_ids, multi_modal_data
+
+async def new_extract_prompt_components_async(
+        self,
+        inputs,
+        request_id,
+        lora_request = None,
+    ):
+    prompt, prompt_token_ids, multi_modal_data = await original_extract_prompt_components_async(
+        self, inputs, request_id, lora_request)
+    prompt_token_ids = lmcache_blend_drop_spt(request_id, prompt_token_ids)
+    return prompt, prompt_token_ids, multi_modal_data
+
+original_llm_engine_init = None
+from vllm.inputs import INPUT_REGISTRY, InputRegistry
+from vllm.usage.usage_lib import UsageContext
+def new_llm_engine_init(
+        self,
+        model_config,
+        cache_config,
+        parallel_config,
+        scheduler_config,
+        device_config,
+        load_config,
+        lora_config,
+        speculative_config,
+        decoding_config,
+        observability_config,
+        prompt_adapter_config,
+        executor_class,
+        log_stats: bool,
+        usage_context: UsageContext = UsageContext.ENGINE_CONTEXT,
+        stat_loggers = None,
+        input_registry: InputRegistry = INPUT_REGISTRY,
+        use_cached_outputs: bool = False,
+    ) -> None:
+    original_llm_engine_init(self,
+                             model_config,
+                             cache_config,
+                             parallel_config,
+                             scheduler_config,
+                             device_config,
+                             load_config,
+                             lora_config,
+                             speculative_config,
+                             decoding_config,
+                             observability_config,
+                             prompt_adapter_config,
+                             executor_class,
+                             log_stats,
+                             usage_context,
+                             stat_loggers,
+                             input_registry,
+                             use_cached_outputs)
+    init_lmcache_engine(model_config, parallel_config, cache_config)
 
 def inject_blend():
     import vllm.attention.backends.abstract
@@ -386,9 +449,22 @@ def inject_blend():
     vllm.worker.model_runner.ModelInputForGPUWithSamplingMetadata.from_broadcasted_tensor_dict = \
     new_from_broadcasted_tensor_dict_with_sampling
 
+    import vllm.inputs.preprocess
+    global original_extract_prompt_components
+    global original_extract_prompt_components_async
+    original_extract_prompt_components = vllm.inputs.preprocess.InputPreprocessor._extract_prompt_components
+    original_extract_prompt_components_async = vllm.inputs.preprocess.InputPreprocessor._extract_prompt_components_async
+    vllm.inputs.preprocess.InputPreprocessor._extract_prompt_components = new_extract_prompt_components
+    vllm.inputs.preprocess.InputPreprocessor._extract_prompt_components_async = new_extract_prompt_components_async
+
+
 def InitLMCacheEnvironment() -> None:
     """Initialize the LMCache environment.
     """
+    import vllm.engine.llm_engine
+    global original_llm_engine_init
+    original_llm_engine_init = vllm.engine.llm_engine.LLMEngine.__init__
+    vllm.engine.llm_engine.LLMEngine.__init__ = new_llm_engine_init
     
     import vllm.worker.model_runner 
     vllm.worker.model_runner.ModelRunner.execute_model = new_execute_model

--- a/lmcache_vllm/vllm_injection.py
+++ b/lmcache_vllm/vllm_injection.py
@@ -16,8 +16,9 @@ from vllm.distributed import get_pp_group
 from lmcache_vllm.vllm_adapter import (lmcache_get_config,
         init_lmcache_engine, lmcache_should_store, lmcache_should_retrieve,
         lmcache_store_kv, lmcache_retrieve_kv, close_lmcache_engine,
-        broadcast_seq_group_metadata, StoreStatus, RetrieveStatus,
+        broadcast_seq_group_metadata, lmcache_blend_drop_spt, StoreStatus, RetrieveStatus,
         SUPPORTED_MODELS)
+from lmcache_vllm.blend_adapter import attach_blend_prompt_indices, remove_request_id_indices
 
 from lmcache_vllm.models.llama import inject_llama
 from lmcache_vllm.attention.flash_attn import inject_flash_attn
@@ -244,7 +245,7 @@ def _new_tokenize_prompt(
                             prompt=prompt,
                             lora_request=lora_request)
     
-    return res
+    return lmcache_blend_drop_spt(request_id, res)
 
 async def _new_tokenize_prompt_async(
     self,
@@ -265,7 +266,7 @@ async def _new_tokenize_prompt_async(
                                         prompt=prompt,
                                         lora_request=lora_request)
     
-    return res
+    return lmcache_blend_drop_spt(request_id, res)
 
 def new_log_task_completion(task: asyncio.Task,
                             error_callback) -> None:
@@ -314,6 +315,28 @@ def wrap_prepare_model_input(
     # at the last stage of pipeline parallelism stages.
     return dataclasses.replace(model_input, seq_group_metadata_list=seq_group_metadata_list)
 
+original_prepare_model_input_tensors = None
+def wrap_prepare_model_input_tensors(
+        self,
+        seq_group_metadata_list,
+        finished_requests_ids: Optional[List[str]] = None
+    ):
+    model_input = original_prepare_model_input_tensors(self,
+        seq_group_metadata_list, finished_requests_ids)
+    attn_metadata = model_input.attn_metadata
+    if attn_metadata is not None:
+        if lmcache_get_config().enable_blending:
+            attach_blend_prompt_indices(seq_group_metadata_list, attn_metadata)
+    return model_input
+
+def new_free_finished_seqs(self, seq_group) -> None:
+    """Free finished seqs in a sequence group."""
+    for seq in seq_group.get_seqs():
+        if seq.is_finished():
+            self.free_seq(seq)
+    if seq_group.is_finished():
+        remove_request_id_indices(seq_group.request_id)
+
 def InitLMCacheEnvironment() -> None:
     """Initialize the LMCache environment.
     """
@@ -328,6 +351,13 @@ def InitLMCacheEnvironment() -> None:
     global original_prepare_model_input
     original_prepare_model_input = vllm.worker.model_runner.ModelRunner.prepare_model_input
     vllm.worker.model_runner.ModelRunner.prepare_model_input = wrap_prepare_model_input
+
+    global original_prepare_model_input_tensors
+    original_prepare_model_input_tensors = vllm.worker.model_runner.ModelRunner._prepare_model_input_tensors
+    vllm.worker.model_runner.ModelRunner._prepare_model_input_tensors = wrap_prepare_model_input_tensors
+
+    import vllm.core.scheduler
+    vllm.core.scheduler.Scheduler._free_finished_seqs = new_free_finished_seqs
     
     import vllm
     vllm.inputs.preprocess.InputPreprocessor._tokenize_prompt = _new_tokenize_prompt

--- a/lmcache_vllm/vllm_injection.py
+++ b/lmcache_vllm/vllm_injection.py
@@ -6,7 +6,8 @@ import torch
 import os
 import asyncio
 import dataclasses
-from typing import Optional, List
+from dataclasses import fields
+from typing import Optional, List, Set, Dict, Any
 
 from vllm.multimodal import MultiModalInputs
 from vllm.lora.request import LoRARequest
@@ -23,6 +24,7 @@ from lmcache_vllm.blend_adapter import attach_blend_prompt_indices
 
 from lmcache_vllm.models.llama import inject_llama
 from lmcache_vllm.attention.flash_attn import inject_flash_attn
+import vllm.worker.model_runner_base
 
 from lmcache.logging import init_logger
 logger = init_logger(__name__)
@@ -338,6 +340,52 @@ def new_free_finished_seqs(self, seq_group) -> None:
     if seq_group.is_finished():
         lmcache_remove_request_id_indices(seq_group.request_id)
 
+
+def new_asdict_zerocopy(self,
+                        skip_fields: Optional[Set[str]] = None
+                        ) -> Dict[str, Any]:
+        """Similar to dataclasses.asdict, but avoids deepcopying."""
+        if skip_fields is None:
+            skip_fields = set()
+        # Note that if we add dataclasses as fields, they will need
+        # similar handling.
+        result = {
+            field.name: getattr(self, field.name)
+            for field in fields(self) if field.name not in skip_fields
+        }
+        if hasattr(self, "blend_metadata"):
+            result["blend_metadata"] = self.blend_metadata
+        return result
+
+
+@classmethod
+def new_from_broadcasted_tensor_dict_with_sampling(
+        cls,
+        tensor_dict: Dict[str, Any],
+        attn_backend: Optional["AttentionBackend"] = None,
+    ) -> "ModelInputForGPUWithSamplingMetadata":
+        from vllm.worker.model_runner_base import _init_sampling_metadata_from_tensor_dict, _init_attn_metadata_from_tensor_dict
+        tensor_dict = _init_sampling_metadata_from_tensor_dict(tensor_dict)
+        if attn_backend is not None:
+            tensor_dict = _init_attn_metadata_from_tensor_dict(
+                attn_backend, tensor_dict)
+        if "blend_metadata" in tensor_dict:
+            assert "attn_metadata" in tensor_dict
+            setattr(tensor_dict["attn_metadata"], "blend_metadata", tensor_dict["blend_metadata"])
+            tensor_dict.pop("blend_metadata")
+
+        return cls(**tensor_dict)
+
+
+
+def inject_blend():
+    import vllm.attention.backends.abstract
+    vllm.attention.backends.abstract.AttentionMetadata.asdict_zerocopy = new_asdict_zerocopy
+
+    import vllm.worker.model_runner
+    vllm.worker.model_runner.ModelInputForGPUWithSamplingMetadata.from_broadcasted_tensor_dict = \
+    new_from_broadcasted_tensor_dict_with_sampling
+
 def InitLMCacheEnvironment() -> None:
     """Initialize the LMCache environment.
     """
@@ -368,3 +416,4 @@ def InitLMCacheEnvironment() -> None:
     if lmcache_get_config().enable_blending:
         inject_llama()
         inject_flash_attn()
+        inject_blend()

--- a/lmcache_vllm/vllm_injection.py
+++ b/lmcache_vllm/vllm_injection.py
@@ -16,9 +16,10 @@ from vllm.distributed import get_pp_group
 from lmcache_vllm.vllm_adapter import (lmcache_get_config,
         init_lmcache_engine, lmcache_should_store, lmcache_should_retrieve,
         lmcache_store_kv, lmcache_retrieve_kv, close_lmcache_engine,
-        broadcast_seq_group_metadata, lmcache_blend_drop_spt, StoreStatus, RetrieveStatus,
+        broadcast_seq_group_metadata, lmcache_blend_drop_spt,
+        lmcache_remove_request_id_indices, StoreStatus, RetrieveStatus,
         SUPPORTED_MODELS)
-from lmcache_vllm.blend_adapter import attach_blend_prompt_indices, remove_request_id_indices
+from lmcache_vllm.blend_adapter import attach_blend_prompt_indices
 
 from lmcache_vllm.models.llama import inject_llama
 from lmcache_vllm.attention.flash_attn import inject_flash_attn
@@ -335,7 +336,7 @@ def new_free_finished_seqs(self, seq_group) -> None:
         if seq.is_finished():
             self.free_seq(seq)
     if seq_group.is_finished():
-        remove_request_id_indices(seq_group.request_id)
+        lmcache_remove_request_id_indices(seq_group.request_id)
 
 def InitLMCacheEnvironment() -> None:
     """Initialize the LMCache environment.

--- a/lmcache_vllm/vllm_injection.py
+++ b/lmcache_vllm/vllm_injection.py
@@ -18,7 +18,7 @@ from lmcache_vllm.vllm_adapter import (lmcache_get_config,
         lmcache_store_kv, lmcache_retrieve_kv, close_lmcache_engine,
         broadcast_seq_group_metadata, lmcache_blend_drop_spt, StoreStatus, RetrieveStatus,
         SUPPORTED_MODELS)
-from lmcache_vllm.blend_adapter import get_blend_indices, remove_request_id_indices
+from lmcache_vllm.blend_adapter import attach_blend_prompt_indices, remove_request_id_indices
 
 from lmcache_vllm.models.llama import inject_llama
 from lmcache_vllm.attention.flash_attn import inject_flash_attn
@@ -326,21 +326,7 @@ def wrap_prepare_model_input_tensors(
     attn_metadata = model_input.attn_metadata
     if attn_metadata is not None:
         if lmcache_get_config().enable_blending:
-            assert not hasattr(attn_metadata, "blend_prompt_indices")
-            setattr(attn_metadata, "blend_prompt_indices", [])
-            seq_lens = attn_metadata.seq_lens
-            seq_data_idx = 0
-            for seq_group_metadata in seq_group_metadata_list:
-                for seqid, seq_data in seq_group_metadata.seq_data.items():
-                    seq_len = seq_lens[seq_data_idx]
-                    if seq_group_metadata.block_tables is not None:
-                        indices = get_blend_indices(seq_group_metadata.request_id, seq_len)
-                    else:
-                        indices = [0, seq_len]
-                    attn_metadata.blend_prompt_indices.append((torch.tensor(
-                        seq_data.get_token_ids()[:seq_len], device="cpu"), indices))
-                    seq_data_idx += 1
-            assert seq_data_idx == len(seq_lens)
+            attach_blend_prompt_indices(seq_group_metadata_list, attn_metadata)
     return model_input
 
 def new_free_finished_seqs(self, seq_group) -> None:


### PR DESCRIPTION
1. Move constant string ENGINE_NAME to another file to avoid circular import.  
2. Since I'm dropping the special tokens in tokenization, and needs to map to those indices when that request is scheduled, there is a ReqId2Indices class to map from request_id to cached indices.
3. Add two injections, one to attach indices and full prompts into attn_metadata for the use of new_request of blend retriever, one to remove the cached indices when a sequence group is finished.